### PR TITLE
PnP command

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -42,6 +42,31 @@ func generateCard(drawer art.Drawer, card *nrdb.Printing, algorithm, designer st
 
 }
 
+func generateCardCanvas(drawer art.Drawer, card *nrdb.Printing, algorithm, designer string) (*canvas.Canvas, error) {
+	cnv := canvas.New(canvasWidth, canvasHeight)
+	ctx := canvas.NewContext(cnv)
+
+	if err := drawer.Draw(ctx, card); err != nil {
+		return nil, err
+	}
+
+	if err := drawFrame(cnv, ctx, card, algorithm, designer); err != nil {
+		return nil, err
+	}
+
+	if drawMarginLines {
+		marginX := (canvasWidth - cardWidth) / 2
+		marginY := (canvasHeight - cardHeight) / 2
+		safeMarginX := (canvasWidth - safeWidth) / 2
+		safeMarginY := (canvasHeight - safeHeight) / 2
+
+		drawMargin(ctx, marginX, marginY, cardWidth, cardHeight, color.White)
+		drawMargin(ctx, safeMarginX, safeMarginY, safeWidth, safeHeight, canvas.Red)
+	}
+
+	return cnv, nil
+}
+
 func drawFrame(cnv *canvas.Canvas, ctx *canvas.Context, card *nrdb.Printing, algorithm, designer string) error {
 	if frame == "none" {
 		return nil
@@ -65,6 +90,7 @@ func drawFrame(cnv *canvas.Canvas, ctx *canvas.Context, card *nrdb.Printing, alg
 	return nil
 
 }
+
 func output(cnv *canvas.Canvas, ctx *canvas.Context, card *nrdb.Printing, algorithm, designer string) error {
 
 	if err := drawFrame(cnv, ctx, card, algorithm, designer); err != nil {

--- a/cmd/pnp.go
+++ b/cmd/pnp.go
@@ -1,0 +1,137 @@
+package cmd
+
+import (
+	"encoding/csv"
+	"github.com/mangofeet/nrdb-go"
+	"github.com/spf13/cobra"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+)
+
+var pnpCmd = &cobra.Command{
+	Use:   "pnp [CSV file]",
+	Args:  cobra.MinimumNArgs(1),
+	Short: "Generate a print & play file containing cards from a CSV",
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := generatePnPFile(args[0]); err != nil {
+			log.Println("error:", err)
+			os.Exit(1)
+		}
+	},
+}
+
+func generatePnPFile(csvPath string) error {
+	f, err := os.Open(csvPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	csvReader := csv.NewReader(f)
+	records, err := csvReader.ReadAll()
+	if err != nil {
+		return err
+	}
+
+	log.Printf("Generating print & play file from %s", csvPath)
+
+	baseColor = "ffffff"
+	frameColorBackground = "ffffff"
+	frameColorFactionBG = "ffffff"
+	frameColorStrengthBG = "ffffff"
+	frameColorInfluenceLimitBG = "ffffff"
+	frameColorMinDeckBG = "ffffff"
+	frameColorBorder = "000000"
+	frameColorText = "000000"
+
+	cardID := startRow
+	for _, record := range records[startRow - 1:] {
+		// Instantiate Printing
+		card := &nrdb.Printing{}
+		card.Attributes = &nrdb.PrintingAttributes{}
+		card.Attributes.CardAbilities = &nrdb.CardAbilities{}
+
+		titleStripper := strings.NewReplacer(" ", "", ".", "", ",", "", "-", "", "!", "", "◆", "")
+
+		// Split summary into sections for ease of use
+		summary_sections := strings.Split(record[5], "====")
+		lower_sections := summary_sections[1]
+		summary_sections = []string{summary_sections[0]}
+		summary_sections = append(summary_sections, strings.Split(lower_sections, "----")...)
+		for i, section := range summary_sections {
+			summary_sections[i] = strings.Trim(section, "\n")
+		}
+
+		// Set ID, faction, name, and type
+		card.ID = strconv.Itoa(cardID)
+		card.Attributes.PositionInSet = cardID
+		if record[1] == "Weyland" {
+			card.Attributes.FactionID = "weyland_consortium"
+		} else {
+			card.Attributes.FactionID = strings.ReplaceAll(strings.ToLower(record[1]), "-", "_")
+		}
+		// card.Attributes.Title = record[3]
+		card.Attributes.Title = record[3]
+		card.Attributes.StrippedTitle = titleStripper.Replace(record[3])
+		card.Attributes.IsUnique = strings.Contains(summary_sections[0], "◆")
+		if record[4] == "Runner-ID" {
+			card.Attributes.CardTypeID = "runner_identity"
+			card.Attributes.CardAbilities.MUProvided = nil
+		} else if record[4] == "Corp-ID" {
+			card.Attributes.CardTypeID = "corp_identity"
+		} else {
+			card.Attributes.CardTypeID = strings.ToLower(record[4])
+		}
+
+		// Set subtypes
+		type_line := strings.Split(summary_sections[1], " ")
+		subtypes := []string{}
+		for _, token := range type_line {
+			if !strings.HasSuffix(token, ":") && token != "-" {
+				subtypes = append(subtypes, token)
+			}
+		}
+		card.Attributes.DisplaySubtypes = new(string)
+		*card.Attributes.DisplaySubtypes = strings.Join(subtypes, "-")
+
+		// Set numeric values
+		cost_line := strings.Split(summary_sections[2], ", ")
+		for _, cost := range cost_line {
+			tokens := strings.Split(cost, ": ")
+			val, _ := strconv.Atoi(tokens[1])
+			switch tokens[0] {
+			case "Advancements":
+				card.Attributes.AdvancementRequirement = &val
+			case "Cost":
+				card.Attributes.Cost = &val
+			case "Deck":
+				card.Attributes.MinimumDeckSize = &val
+			case "Influence":
+				card.Attributes.InfluenceCost = &val
+				card.Attributes.InfluenceLimit = &val
+			case "Memory":
+				card.Attributes.MemoryCost = &val
+			case "Points":
+				card.Attributes.AgendaPoints = &val
+			case "Strength":
+				card.Attributes.Strength = &val
+			case "Trash":
+				card.Attributes.MinimumDeckSize = &val
+			}
+		}
+
+		// Set text
+		card.Attributes.Text = strings.Trim(summary_sections[3], "\n")
+
+		err := generateCard(emptyDrawer{}, card, "", "")
+		if err != nil {
+			return err
+		}
+
+		cardID += 1
+	}
+
+	return nil
+}

--- a/cmd/pnp.go
+++ b/cmd/pnp.go
@@ -72,6 +72,7 @@ func generatePnPFile(csvPath string) error {
 	frameColorBackground = "ffffff"
 	frameColorFactionBG = "ffffff"
 	frameColorStrengthBG = "ffffff"
+	frameColorInfluenceBG = "ffffff"
 	frameColorInfluenceLimitBG = "ffffff"
 	frameColorMinDeckBG = "ffffff"
 	frameColorBorder = "000000"

--- a/cmd/pnp.go
+++ b/cmd/pnp.go
@@ -2,8 +2,12 @@ package cmd
 
 import (
 	"encoding/csv"
+	"fmt"
 	"github.com/mangofeet/nrdb-go"
 	"github.com/spf13/cobra"
+	"github.com/tdewolff/canvas"
+	"github.com/tdewolff/canvas/renderers/pdf"
+	"github.com/tdewolff/canvas/renderers/rasterizer"
 	"log"
 	"os"
 	"strconv"
@@ -23,20 +27,47 @@ var pnpCmd = &cobra.Command{
 }
 
 func generatePnPFile(csvPath string) error {
-	f, err := os.Open(csvPath)
+	const (
+		PAGE_WIDTH_MM  = 210
+		PAGE_HEIGHT_MM = 297
+		CARD_WIDTH_MM  = 60.0
+	)
+
+	// Load CSV file
+	csvFile, err := os.Open(csvPath)
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer csvFile.Close()
 
-	csvReader := csv.NewReader(f)
+	csvReader := csv.NewReader(csvFile)
 	records, err := csvReader.ReadAll()
 	if err != nil {
 		return err
 	}
 
-	log.Printf("Generating print & play file from %s", csvPath)
+	// Create output directory
+	if err := os.MkdirAll(outputDir, os.ModePerm); err != nil {
+		return err
+	}
 
+	// Open PDF file
+	pdfFilePath := fmt.Sprintf("%s/pnp.pdf", outputDir)
+	log.Printf("Generating print & play file at %s", pdfFilePath)
+	pdfFile, err := os.Create(pdfFilePath)
+	if err != nil {
+		return err
+	}
+	defer pdfFile.Close()
+
+	// Instantiate variables
+	p := pdf.New(pdfFile, PAGE_WIDTH_MM, PAGE_HEIGHT_MM, nil)
+	pdfCanvas := canvas.New(PAGE_WIDTH_MM, PAGE_HEIGHT_MM)
+	pdfContext := canvas.NewContext(pdfCanvas)
+	pageMarginX := (PAGE_WIDTH_MM - (CARD_WIDTH_MM * 3)) / 2
+	pageMarginY := -1.0
+
+	// Override colors to black & white
 	baseColor = "ffffff"
 	frameColorBackground = "ffffff"
 	frameColorFactionBG = "ffffff"
@@ -47,91 +78,134 @@ func generatePnPFile(csvPath string) error {
 	frameColorText = "000000"
 
 	cardID := startRow
-	for _, record := range records[startRow - 1:] {
-		// Instantiate Printing
-		card := &nrdb.Printing{}
-		card.Attributes = &nrdb.PrintingAttributes{}
-		card.Attributes.CardAbilities = &nrdb.CardAbilities{}
+	for i, record := range records[startRow-1:] {
+		card := buildCard(record, cardID)
 
-		titleStripper := strings.NewReplacer(" ", "", ".", "", ",", "", "-", "", "!", "", "◆", "")
-
-		// Split summary into sections for ease of use
-		summary_sections := strings.Split(record[5], "====")
-		lower_sections := summary_sections[1]
-		summary_sections = []string{summary_sections[0]}
-		summary_sections = append(summary_sections, strings.Split(lower_sections, "----")...)
-		for i, section := range summary_sections {
-			summary_sections[i] = strings.Trim(section, "\n")
-		}
-
-		// Set ID, faction, name, and type
-		card.ID = strconv.Itoa(cardID)
-		card.Attributes.PositionInSet = cardID
-		if record[1] == "Weyland" {
-			card.Attributes.FactionID = "weyland_consortium"
-		} else {
-			card.Attributes.FactionID = strings.ReplaceAll(strings.ToLower(record[1]), "-", "_")
-		}
-		// card.Attributes.Title = record[3]
-		card.Attributes.Title = record[3]
-		card.Attributes.StrippedTitle = titleStripper.Replace(record[3])
-		card.Attributes.IsUnique = strings.Contains(summary_sections[0], "◆")
-		if record[4] == "Runner-ID" {
-			card.Attributes.CardTypeID = "runner_identity"
-			card.Attributes.CardAbilities.MUProvided = nil
-		} else if record[4] == "Corp-ID" {
-			card.Attributes.CardTypeID = "corp_identity"
-		} else {
-			card.Attributes.CardTypeID = strings.ToLower(record[4])
-		}
-
-		// Set subtypes
-		type_line := strings.Split(summary_sections[1], " ")
-		subtypes := []string{}
-		for _, token := range type_line {
-			if !strings.HasSuffix(token, ":") && token != "-" {
-				subtypes = append(subtypes, token)
-			}
-		}
-		card.Attributes.DisplaySubtypes = new(string)
-		*card.Attributes.DisplaySubtypes = strings.Join(subtypes, "-")
-
-		// Set numeric values
-		cost_line := strings.Split(summary_sections[2], ", ")
-		for _, cost := range cost_line {
-			tokens := strings.Split(cost, ": ")
-			val, _ := strconv.Atoi(tokens[1])
-			switch tokens[0] {
-			case "Advancements":
-				card.Attributes.AdvancementRequirement = &val
-			case "Cost":
-				card.Attributes.Cost = &val
-			case "Deck":
-				card.Attributes.MinimumDeckSize = &val
-			case "Influence":
-				card.Attributes.InfluenceCost = &val
-				card.Attributes.InfluenceLimit = &val
-			case "Memory":
-				card.Attributes.MemoryCost = &val
-			case "Points":
-				card.Attributes.AgendaPoints = &val
-			case "Strength":
-				card.Attributes.Strength = &val
-			case "Trash":
-				card.Attributes.MinimumDeckSize = &val
-			}
-		}
-
-		// Set text
-		card.Attributes.Text = strings.Trim(summary_sections[3], "\n")
-
-		err := generateCard(emptyDrawer{}, card, "", "")
+		// Generate card image
+		cnv, err := generateCardCanvas(emptyDrawer{}, card, "", "")
 		if err != nil {
 			return err
 		}
 
+		// Calculate card dimensions
+		cardImg := rasterizer.Draw(cnv, canvas.DPMM(1), canvas.DefaultColorSpace)
+		imgDPMM := float64(cardImg.Bounds().Max.X) / CARD_WIDTH_MM
+		imgWidth := float64(cardImg.Bounds().Max.X) / imgDPMM
+		imgHeight := float64(cardImg.Bounds().Max.Y) / imgDPMM
+		if pageMarginY == -1 {
+			pageMarginY = (PAGE_HEIGHT_MM - (imgHeight * 3)) / 2
+		}
+
+		// Draw image
+		imageIndex := i % 9
+		pageX := pageMarginX + (float64(i%3) * imgWidth)
+		pageY := PAGE_HEIGHT_MM - (float64((imageIndex/3)+1) * imgHeight) - pageMarginY
+		pdfContext.DrawImage(pageX, pageY, cardImg, canvas.DPMM(imgDPMM))
+
 		cardID += 1
+
+		// Quit if we reached the last record
+		if i == len(records)-startRow-1 {
+			break
+		}
+
+		// Render the page and create a new one
+		if i%9 == 8 {
+			pdfCanvas.RenderTo(p)
+
+			p.NewPage(PAGE_WIDTH_MM, PAGE_HEIGHT_MM)
+			pdfCanvas = canvas.New(PAGE_WIDTH_MM, PAGE_HEIGHT_MM)
+			pdfContext = canvas.NewContext(pdfCanvas)
+		}
+	}
+
+	// Render the last page
+	pdfCanvas.RenderTo(p)
+
+	if err := p.Close(); err != nil {
+		return err
 	}
 
 	return nil
+}
+
+func buildCard(record []string, cardID int) *nrdb.Printing {
+	// Instantiate Printing
+	card := &nrdb.Printing{}
+	card.Attributes = &nrdb.PrintingAttributes{}
+	card.Attributes.CardAbilities = &nrdb.CardAbilities{}
+
+	titleStripper := strings.NewReplacer(" ", "", ".", "", ",", "", "-", "", "!", "", "◆", "")
+
+	// Split summary into sections for ease of use
+	summary_sections := strings.Split(record[5], "====")
+	lower_sections := summary_sections[1]
+	summary_sections = []string{summary_sections[0]}
+	summary_sections = append(summary_sections, strings.Split(lower_sections, "----")...)
+	for i, section := range summary_sections {
+		summary_sections[i] = strings.Trim(section, "\n")
+	}
+
+	// Set ID, faction, name, and type
+	card.ID = strconv.Itoa(cardID)
+	card.Attributes.PositionInSet = cardID
+	if record[1] == "Weyland" {
+		card.Attributes.FactionID = "weyland_consortium"
+	} else {
+		card.Attributes.FactionID = strings.ReplaceAll(strings.ToLower(record[1]), "-", "_")
+	}
+	// card.Attributes.Title = record[3]
+	card.Attributes.Title = record[3]
+	card.Attributes.StrippedTitle = titleStripper.Replace(record[3])
+	card.Attributes.IsUnique = strings.Contains(summary_sections[0], "◆")
+	if record[4] == "Runner-ID" {
+		card.Attributes.CardTypeID = "runner_identity"
+		card.Attributes.CardAbilities.MUProvided = nil
+	} else if record[4] == "Corp-ID" {
+		card.Attributes.CardTypeID = "corp_identity"
+	} else {
+		card.Attributes.CardTypeID = strings.ToLower(record[4])
+	}
+
+	// Set subtypes
+	type_line := strings.Split(summary_sections[1], " ")
+	subtypes := []string{}
+	for _, token := range type_line {
+		if !strings.HasSuffix(token, ":") && token != "-" {
+			subtypes = append(subtypes, token)
+		}
+	}
+	card.Attributes.DisplaySubtypes = new(string)
+	*card.Attributes.DisplaySubtypes = strings.Join(subtypes, "-")
+
+	// Set numeric values
+	cost_line := strings.Split(summary_sections[2], ", ")
+	for _, cost := range cost_line {
+		tokens := strings.Split(cost, ": ")
+		val, _ := strconv.Atoi(tokens[1])
+		switch tokens[0] {
+		case "Advancements":
+			card.Attributes.AdvancementRequirement = &val
+		case "Cost":
+			card.Attributes.Cost = &val
+		case "Deck":
+			card.Attributes.MinimumDeckSize = &val
+		case "Influence":
+			card.Attributes.InfluenceCost = &val
+			card.Attributes.InfluenceLimit = &val
+		case "Memory":
+			card.Attributes.MemoryCost = &val
+		case "Points":
+			card.Attributes.AgendaPoints = &val
+		case "Strength":
+			card.Attributes.Strength = &val
+		case "Trash":
+			card.Attributes.MinimumDeckSize = &val
+		}
+	}
+
+	// Set text
+	card.Attributes.Text = strings.Trim(summary_sections[3], "\n")
+
+	return card
 }

--- a/cmd/pnp.go
+++ b/cmd/pnp.go
@@ -10,6 +10,7 @@ import (
 	"github.com/tdewolff/canvas/renderers/rasterizer"
 	"log"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 )
@@ -155,8 +156,7 @@ func buildCard(record []string, cardID int) *nrdb.Printing {
 	} else {
 		card.Attributes.FactionID = strings.ReplaceAll(strings.ToLower(record[1]), "-", "_")
 	}
-	// card.Attributes.Title = record[3]
-	card.Attributes.Title = record[3]
+	card.Attributes.Title = strings.ReplaceAll(record[3], "\n", "")
 	card.Attributes.StrippedTitle = titleStripper.Replace(record[3])
 	card.Attributes.IsUnique = strings.Contains(summary_sections[0], "◆")
 	if record[4] == "Runner-ID" {
@@ -207,6 +207,13 @@ func buildCard(record []string, cardID int) *nrdb.Printing {
 
 	// Set text
 	card.Attributes.Text = strings.Trim(summary_sections[3], "\n")
+	card.Attributes.Text = strings.ReplaceAll(card.Attributes.Text, "{mu}", "[mu]")
+	card.Attributes.Text = strings.ReplaceAll(card.Attributes.Text, "{c}", "[credit]")
+	card.Attributes.Text = strings.ReplaceAll(card.Attributes.Text, "{recurring}", "[recurring-credit]")
+	card.Attributes.Text = strings.ReplaceAll(card.Attributes.Text, "{click}", "[click]")
+	card.Attributes.Text = strings.ReplaceAll(card.Attributes.Text, "{sub}", "[subroutine]")
+	card.Attributes.Text = strings.ReplaceAll(card.Attributes.Text, "{trash}", "[trash]")
+	card.Attributes.Text = strings.ReplaceAll(card.Attributes.Text, "{interrupt}", "[interrupt]")
 
 	return card
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 
+	"github.com/mangofeet/netrunner-alt-gen/frame/basic"
 	"github.com/spf13/cobra"
 )
 
@@ -24,12 +25,12 @@ import (
 
 // based on MPC template
 
-const canvasWidth = 3264.0
-const canvasHeight = 4450.0
-const cardWidth = 2976.0
-const cardHeight = 4152.0
-const safeWidth = 2736.0
-const safeHeight = 3924.0
+// const canvasWidth = 3264.0
+// const canvasHeight = 4450.0
+// const cardWidth = 2976.0
+// const cardHeight = 4152.0
+// const safeWidth = 2736.0
+// const safeHeight = 3924.0
 
 // real card MM, doesn't work currently, need higehr res for
 // generation
@@ -40,12 +41,14 @@ const safeHeight = 3924.0
 // const cardHeight = 88.0
 
 var (
+	canvasWidth, canvasHeight, cardWidth, cardHeight, safeWidth, safeHeight float64 = 3264.0, 4450.0, 2976.0, 4152.0, 2736.0, 3924.0
+
 	drawMarginLines, makeBack                             bool
 	outputDir                                             string
 	baseColor, altColor1, altColor2, altColor3, altColor4 string
 	skipFlavor                                            bool
 	flavorText, flavorAttribution                         string
-	textBoxFactor                                         float64
+	textBoxFactor, scaleFactor                            float64
 
 	frame, frameColorBackground, frameColorBorder, frameColorText,
 	frameColorTextStrength, frameColorInfluencePips,
@@ -79,6 +82,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&skipFlavor, "skip-flavor", "", false, `Don't render default flavor text`)
 	rootCmd.PersistentFlags().StringVarP(&baseColor, "base-color", "c", "", `Alternate base color for the card, defaults to pre-defined faction colors`)
 	rootCmd.PersistentFlags().Float64VarP(&textBoxFactor, "text-box-height", "", 33.3, `Percentage of total card height taken up by the main text box`)
+	rootCmd.PersistentFlags().Float64VarP(&scaleFactor, "scale-factor", "", 1.0, `Scaling factor of entire image, defaults to 1.0 (1.0 = 1200DPI)`)
 
 	rootCmd.PersistentFlags().StringVarP(&frame, "frame", "f", "basic", `Frame to draw, use "none" to skip drawing a frame`)
 	rootCmd.PersistentFlags().StringVarP(&frameColorBackground, "frame-color-background", "", "1c1c1c99", `Background color for frame text boxes`)
@@ -160,6 +164,15 @@ var rootCmd = &cobra.Command{
 	Short: "netrunner-alt-gen generates alt arts for Netrunner",
 	Long: `A generative art tool to create alternate art cards with tournament legal frames for Netrunner.
   Complete documentation is available at https://github.com/mangofeet/netrunner-alt-gen`,
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		canvasWidth *= scaleFactor
+		canvasHeight *= scaleFactor
+		cardWidth *= scaleFactor
+		cardHeight *= scaleFactor
+		safeWidth *= scaleFactor
+		safeHeight *= scaleFactor
+		basic.ScaleFactor = scaleFactor
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		log.Println("Version:", version)
 		cmd.Usage()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -62,6 +62,9 @@ var (
 	// image
 	designer string
 
+	// pnp
+	startRow int
+
 	// set by ldflags
 	version string = "local"
 )
@@ -120,6 +123,8 @@ If set to "faction", it will use the faction color regardless of the base color`
 	trackerCmd.Flags().StringVarP(&altColor4, "ring-color-4", "", "", `Alternate ring color for the card, defaults to faction color made more transparent`)
 	trackerCmd.Flags().StringVarP(&colorBG, "color-bg", "", "", `Background color for the generated art, defaults to a darkened --base-color value`)
 
+	pnpCmd.Flags().IntVarP(&startRow, "start-row", "m", 2, `Row to start generating from, defaults to 1 (this assumes the CSV contains a header row)`)
+
 	rootCmd.AddCommand(netwalkerCmd)
 	rootCmd.AddCommand(emptyCmd)
 	rootCmd.AddCommand(imageCmd)
@@ -128,6 +133,7 @@ If set to "faction", it will use the faction color regardless of the base color`
 	rootCmd.AddCommand(anglemorphCmd)
 	rootCmd.AddCommand(reflectionCmd)
 	rootCmd.AddCommand(trackerCmd)
+	rootCmd.AddCommand(pnpCmd)
 }
 
 func commonNetspaceFlags(cmd *cobra.Command) {

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -46,7 +46,7 @@ func getFramer(card *nrdb.Printing, algorithm, designer string) (art.Drawer, err
 		return frm.Tracker(), nil
 	case "basic":
 		var framer art.Drawer
-		log.Println("card type:", card.Attributes.CardTypeID)
+		log.Printf("Card: %s, type: %s", card.Attributes.Title, card.Attributes.CardTypeID)
 
 		if flavorText != "" {
 			frm.Flavor = "<em>" + flavorText + "</em>"

--- a/frame/basic/basic.go
+++ b/frame/basic/basic.go
@@ -89,7 +89,7 @@ func (fb FrameBasic) getColorInfluenceBG(card *nrdb.Printing) color.RGBA {
 	return art.GetFactionBaseColor(card.Attributes.FactionID)
 }
 
-func (fb FrameBasic) getColorStrenthBG(card *nrdb.Printing) color.RGBA {
+func (fb FrameBasic) getColorStrengthBG(card *nrdb.Printing) color.RGBA {
 
 	if fb.ColorStrengthBG != nil {
 		return *fb.ColorStrengthBG

--- a/frame/basic/ice.go
+++ b/frame/basic/ice.go
@@ -114,7 +114,7 @@ func (fb FrameBasic) Ice() art.Drawer {
 		// program strength
 		ctx.Push()
 
-		ctx.SetFillColor(fb.getColorStrenthBG(card))
+		ctx.SetFillColor(fb.getColorStrengthBG(card))
 		ctx.SetStrokeColor(fb.getColorBorder())
 		ctx.SetStrokeWidth(strokeWidth)
 

--- a/frame/basic/program.go
+++ b/frame/basic/program.go
@@ -62,7 +62,7 @@ func (fb FrameBasic) Program() art.Drawer {
 		// program strength
 		ctx.Push()
 
-		ctx.SetFillColor(fb.getColorStrenthBG(card))
+		ctx.SetFillColor(fb.getColorStrengthBG(card))
 		ctx.SetStrokeColor(fb.getColorBorder())
 		ctx.SetStrokeWidth(strokeWidth)
 

--- a/frame/basic/shapes.go
+++ b/frame/basic/shapes.go
@@ -11,6 +11,8 @@ import (
 	"github.com/tdewolff/canvas"
 )
 
+var ScaleFactor float64
+
 func getStrokeWidth(ctx *canvas.Context) float64 {
 	_, canvasHeight := ctx.Size()
 	// return canvasHeight * 0.0023
@@ -89,7 +91,7 @@ func (fb FrameBasic) drawRezCost(ctx *canvas.Context, card *nrdb.Printing, fontS
 	if err != nil {
 		return nil, err
 	}
-	rezCostImage = rezCostImage.Transform(canvas.Identity.ReflectY()).Scale(0.1, 0.1)
+	rezCostImage = rezCostImage.Transform(canvas.Identity.ReflectY()).Scale(0.1, 0.1).Scale(ScaleFactor, ScaleFactor)
 
 	ctx.Push()
 	ctx.SetFillColor(fb.getColorBG())
@@ -130,7 +132,7 @@ func (fb FrameBasic) drawAgendaPoints(ctx *canvas.Context, card *nrdb.Printing, 
 	if err != nil {
 		return nil, err
 	}
-	icon = icon.Transform(canvas.Identity.ReflectY()).Scale(0.07, 0.07)
+	icon = icon.Transform(canvas.Identity.ReflectY()).Scale(0.07, 0.07).Scale(ScaleFactor, ScaleFactor)
 
 	iconX := canvasWidth * 0.085
 	iconY := fb.getTextBoxHeight(ctx) + icon.Bounds().H*1.8
@@ -238,7 +240,7 @@ func (fb FrameBasic) drawMU(ctx *canvas.Context, card *nrdb.Printing, drawBox bo
 	if err != nil {
 		panic(err)
 	}
-	muImage = muImage.Transform(canvas.Identity.ReflectY()).Scale(0.05, 0.05)
+	muImage = muImage.Transform(canvas.Identity.ReflectY()).Scale(0.05, 0.05).Scale(ScaleFactor, ScaleFactor)
 
 	muBoxX := canvasWidth * 0.0853
 	muBoxY := (getTitleBoxTop(ctx) - getTitleBoxHeight(ctx)) - (muImage.Bounds().H * 0.8)
@@ -305,7 +307,7 @@ func (fb FrameBasic) drawLink(ctx *canvas.Context, card *nrdb.Printing) {
 	if err != nil {
 		panic(err)
 	}
-	icon = icon.Transform(canvas.Identity.ReflectY()).Scale(0.015, 0.015)
+	icon = icon.Transform(canvas.Identity.ReflectY()).Scale(0.015, 0.015).Scale(ScaleFactor, ScaleFactor)
 
 	boxX := canvasWidth * 0.1
 	boxY := getTitleBoxTop(ctx) - getTitleBoxHeight(ctx)*0.6

--- a/frame/basic/text.go
+++ b/frame/basic/text.go
@@ -81,7 +81,7 @@ func (fb FrameBasic) getHorizontalFittedTextWithFont(ctx *canvas.Context, title 
 
 	strokeWidth := getStrokeWidth(ctx)
 
-	for text.Bounds().W > maxWidth {
+	for text.Bounds().W > maxWidth && fontSize > 0 {
 		fontSize -= strokeWidth
 		text = fb.getCardTextWithFont(title, fontSize, maxWidth*2, height, align, font)
 	}


### PR DESCRIPTION
# `pnp` command
These changes add a `pnp` command to generate a print & play PDF out of a CSV file in NSG's current playtesting format.

This is very rudimentary and mostly self-explanatory, but the highlights of the `pnp` command are:
- It accepts a path to a CSV file
- It accepts the `--start-row` parameter to allow the user to only generate cards from the specified row in the spreadsheet. The row is assumed to be 1-indexed and the spreadsheet is assumed to contain a header row, so only values >= 2 are accepted.
- It explicitly overrides many of the color values to black and white and will ignore whatever the user specifies. There's probably a more elegant way to handle this, but I think it makes sense for a print & play file.

# Potential bug
I made an unrelated change as an attempted quick & dirty fix for a possible bug:
The text bounds in `FrameBasic::getHorizontalFittedTextWithFont()` never change in some cases, causing the loop to never terminate. Checking for a negative `fontSize` is a sloppy workaround to detect when we should stop trying to resize the font and let it print out whatever it has, possibly breaking the formatting.

A few card titles triggered this, but the first one I noticed this happening for was "Humanoid Resources".  Indeed, in the resulting output, the card title simply states "Humanoid" (presumably it word wrapped and cut the rest off?).

I didn't look into this further to try to figure out why font resizing and math wasn't working out.